### PR TITLE
fix broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Learn how to use the library in the [docs](tree/master/docs/library). Examples c
 Future development of the platform will include an IDE (like Arduino Create). Current OTA only allows uploading of a compiled binary file. Future development will also optimize the process and allow a ~70% flash size usage, but current process limits you to 50% flash size. It means that if your board has flash size (PROGRAM) of 4MB, then your sketch can only use 50% of it (2MB). That is because the new firmware has to be stored alongside current firmware for update. You can extract your compiled binary file quite easily with [Arduino IDE][Arduino-IDE-Binary] and [PlatformIO][PlatformIO-Binary].
 
 ## Self Hosting
-You can host the platform and all communication handling on your own server. You are going to need a linux machine and a firebase account. Check out the [step by step tutorial](tree/master/docs/slef-hosting)
+You can host the platform and all communication handling on your own server. You are going to need a linux machine and a firebase account. Check out the [step by step tutorial](docs/self-hosting)
 
 ## Supported Boards 
 As of now, only ESP8266 is supported. I do wish to add support for as many boards as possible. Any help with this task is appreciated.


### PR DESCRIPTION
Previous link was broken due to both spelling, and relative path problems. Link need to be either absolute (`https://github.com/ItayRosen/OpenIoT/blob/master/docs/self-hosting`) or relative (`docs/self-hosting`). (See [Gitlab Blog - Relative links in Markup files](https://github.blog/2013-01-31-relative-links-in-markup-files/))


I chose relative, since I believe that serves best to make sure the docs are always relative to the version of the README being read no matter where it sits (and wouldn't need to be changed in the event this product becomes extremely popular and repo is moved to an Org)

If you want for me to resubmit as absolute link, just lmk.