### PR TITLE
WIP: Implement Docker webui

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,12 +18,22 @@ services:
       - certs:/etc/letsencrypt/live
     restart: unless-stopped
 
+  openiot_web:
+    build:
+      context: ./
+      dockerfile: docker/web/Dockerfile
+    image: openiot:web
+    container_name: web
+    ports:
+      - 9005:80
+    networks:
+      - web
 
 volumes:
   letsencrypt-config:
   certs:
   cert-config:
 
-
 networks:
   proxy:
+  web:

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:latest AS build
+
+COPY platform /platform
+
+WORKDIR /platform
+
+RUN npm install \
+  && npm run build
+
+FROM nginx:1.16.0 AS prod
+
+COPY --from=build /platform/build /usr/share/nginx/html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Work in progress. So far running `docker-compose up -d` will allow you to visit localhost:9005 to view the front-end.  (given time to install npm modules and webpack build)

Remaining features to implement:
- [ ] update `location` block of `docker/proxy/site.conf` to forward requests to the frontend container
- [ ] look at ways to provide dynamic configuration of constants used during the build stage of this service
- [ ] document this component in the `docs/self-hosting/docker.md` file
- [ ] remove host port-mapping (should be accessed via the proxy for the prod compose)